### PR TITLE
Bundle DynamicProxy in Stunts itself for convenience

### DIFF
--- a/Stunts.sln
+++ b/Stunts.sln
@@ -33,8 +33,6 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Stunts.StaticProxy", "src\S
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Stunts.DynamicProxy", "src\Stunts.DynamicProxy\Stunts.DynamicProxy.csproj", "{EE910E63-2490-434C-961E-83C088ADC5C2}"
 EndProject
-Project("{13B669BE-BB05-4DDF-9536-439F39A36129}") = "Pack", "src\Pack\Pack.msbuildproj", "{4A1785A4-3CE1-4E13-A267-769574AF4F05}"
-EndProject
 Project("{778DAE3C-4631-46EA-AA77-85C1314464D9}") = "Stunts.Basic", "src\Stunts.Basic\Stunts.Basic.vbproj", "{851DF623-1CD9-4A3A-8EB6-9999710BF40A}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Stunts.IntegrationTests", "src\Stunts.IntegrationTests\Stunts.IntegrationTests.csproj", "{349999C7-0F55-460C-BBB2-8C45D7BC00E8}"
@@ -79,10 +77,6 @@ Global
 		{EE910E63-2490-434C-961E-83C088ADC5C2}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{EE910E63-2490-434C-961E-83C088ADC5C2}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{EE910E63-2490-434C-961E-83C088ADC5C2}.Release|Any CPU.Build.0 = Release|Any CPU
-		{4A1785A4-3CE1-4E13-A267-769574AF4F05}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{4A1785A4-3CE1-4E13-A267-769574AF4F05}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{4A1785A4-3CE1-4E13-A267-769574AF4F05}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{4A1785A4-3CE1-4E13-A267-769574AF4F05}.Release|Any CPU.Build.0 = Release|Any CPU
 		{851DF623-1CD9-4A3A-8EB6-9999710BF40A}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{851DF623-1CD9-4A3A-8EB6-9999710BF40A}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{851DF623-1CD9-4A3A-8EB6-9999710BF40A}.Release|Any CPU.ActiveCfg = Release|Any CPU

--- a/samples/Samples/Samples.csproj
+++ b/samples/Samples/Samples.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <TargetFrameworks>net472;net5.0</TargetFrameworks>
     <Nullable>enable</Nullable>
+    <ProduceReferenceAssembly>false</ProduceReferenceAssembly>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Acceptance/Directory.Build.props
+++ b/src/Acceptance/Directory.Build.props
@@ -2,6 +2,7 @@
   <PropertyGroup>
     <LangVersion>Preview</LangVersion>
     <VersionPrefix>42.42.42</VersionPrefix>
+    <Nullable>annotations</Nullable>
     <RestoreSources>
       $(MSBuildThisFileDirectory)../../bin;
       https://api.nuget.org/v3/index.json

--- a/src/Acceptance/Dynamic/Dynamic.csproj
+++ b/src/Acceptance/Dynamic/Dynamic.csproj
@@ -2,13 +2,8 @@
 
   <PropertyGroup>
     <TargetFrameworks>net472;net5.0</TargetFrameworks>
+    <RegisterStaticStuntFactory>false</RegisterStaticStuntFactory>
   </PropertyGroup>
-
-  <ItemGroup>
-    <Compile Include="..\..\ManualStunts\CalculatorMode.cs" Link="CalculatorMode.cs" />
-    <Compile Include="..\..\ManualStunts\ICalculator.cs" Link="ICalculator.cs" />
-    <Compile Include="..\..\ManualStunts\ICalculatorMemory.cs" Link="ICalculatorMemory.cs" />
-  </ItemGroup>
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.7.1" />
@@ -16,7 +11,8 @@
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3" />
     <PackageReference Include="Stunts" Version="$(Version)" />
-    <PackageReference Include="Stunts.DynamicProxy" Version="$(Version)" />
+    <PackageReference Include="ManualStunts" Version="$(Version)" />
+    <PackageReference Include="Microsoft.Bcl.HashCode" Version="1.1.0" />
   </ItemGroup>
 
 </Project>

--- a/src/Acceptance/Static/Static.csproj
+++ b/src/Acceptance/Static/Static.csproj
@@ -5,17 +5,13 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <Compile Include="..\..\ManualStunts\CalculatorMode.cs" Link="CalculatorMode.cs" />
-    <Compile Include="..\..\ManualStunts\ICalculator.cs" Link="ICalculator.cs" />
-    <Compile Include="..\..\ManualStunts\ICalculatorMemory.cs" Link="ICalculatorMemory.cs" />
-  </ItemGroup>
-
-  <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.7.1" />
     <PackageReference Include="Microsoft.TestPlatform.ObjectModel" Version="16.7.1" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3" />
     <PackageReference Include="Stunts" Version="$(Version)" />
+    <PackageReference Include="ManualStunts" Version="$(Version)" />
+    <PackageReference Include="Microsoft.Bcl.HashCode" Version="1.1.0" />
   </ItemGroup>
 
 </Project>

--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -37,7 +37,7 @@
   <ItemGroup Label="Tests">
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="16.7.1" />
     <PackageVersion Include="Microsoft.TestPlatform.ObjectModel" Version="16.7.1" />
-    <PackageVersion Include="Moq" Version="4.14.5" />
+    <PackageVersion Include="Moq" Version="4.14.7" />
     <PackageVersion Include="xunit" Version="2.4.1" />
     <PackageVersion Include="xunit.runner.console" Version="2.4.1" />
     <PackageVersion Include="xunit.runner.msbuild" Version="2.4.1" />

--- a/src/Stunts.CodeAnalysis/Stunts.CodeAnalysis.props
+++ b/src/Stunts.CodeAnalysis/Stunts.CodeAnalysis.props
@@ -1,3 +1,0 @@
-<Project>
-
-</Project>

--- a/src/Stunts.DynamicProxy/Stunts.DynamicProxy.csproj
+++ b/src/Stunts.DynamicProxy/Stunts.DynamicProxy.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
-    <IsPackable>true</IsPackable>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>
       Provides run-time stunt generation using Castle DynamicProxy, for projects that 
       cannot use the compile-time stunt generation provided built-in Stunts, which 
@@ -16,7 +16,6 @@
 
   <ItemGroup>
     <ProjectReference Include="..\Stunts\Stunts.csproj" Pack="false" />
-    <ProjectReference Include="..\Stunts.Package\Stunts.Package.msbuildproj" ReferenceOutputAssembly="false" />
   </ItemGroup>
   
   <ItemGroup>

--- a/src/Stunts.DynamicProxy/Stunts.DynamicProxy.props
+++ b/src/Stunts.DynamicProxy/Stunts.DynamicProxy.props
@@ -1,9 +1,0 @@
-<Project>
-
-  <PropertyGroup>
-    <DynamicStuntFactory>Stunts.Sdk.DynamicStuntFactory, Stunts.DynamicProxy, PublicKeyToken=$(StuntsPublicKeyToken)</DynamicStuntFactory>
-    <!-- Installing the dynamic one turns off the static built-in one -->
-    <RegisterStaticStuntFactory>false</RegisterStaticStuntFactory>
-  </PropertyGroup>
-
-</Project>

--- a/src/Stunts.DynamicProxy/Stunts.DynamicProxy.targets
+++ b/src/Stunts.DynamicProxy/Stunts.DynamicProxy.targets
@@ -1,30 +1,11 @@
 <Project>
 
-  <ItemGroup>
-    <StuntFactory Include="$(DynamicStuntFactory)" 
-                  PackageId="Stunts.DynamicProxy"
-                  Condition="'$(RegisterDynamicStuntFactory)' != 'false'" />
+  <PropertyGroup>
+    <DynamicStuntFactory>Stunts.Sdk.DynamicStuntFactory, Stunts.DynamicProxy, PublicKeyToken=$(StuntsPublicKeyToken)</DynamicStuntFactory>
+  </PropertyGroup>
+
+  <ItemGroup Condition="'$(RegisterDynamicStuntFactory)' != 'false'">
+    <StuntFactory Include="$(DynamicStuntFactory)" PackageId="Stunts" />
   </ItemGroup>
-
-  <Target Name="EnsureDynamicStuntFactory" 
-          BeforeTargets="BeforeCompile;CoreCompile"
-          Condition="'$(RegisterDynamicStuntFactory)' != 'false'">
-
-    <!-- NOTE: we do this in a targets rather than just making StuntFactoryAttribute AllowMultiple=false 
-         because this will be significantly user-friendlier, since the attribute is a generated one and 
-         users won't know where the duplicate is coming from otherwise. -->
-
-    <PropertyGroup>
-      <StuntFactories>@(StuntFactory -> Count())</StuntFactories>
-    </PropertyGroup>
-    
-    <ItemGroup>
-      <_OtherStuntFactories Include="@(StuntFactory -> '%(PackageId)')" Exclude="Stunts.DynamicProxy" />
-    </ItemGroup>
-
-    <Error Code="STB003" Condition="$(StuntFactories) &gt; '1'"
-           Text="More than one stunt factory is registered in the current project. Set RegisterDynamicStuntFactory=false or remove the other package(s) providing factories: @(_OtherStuntFactories, ', ')." />
-
-  </Target>
 
 </Project>

--- a/src/Stunts.Package/Stunt.cs
+++ b/src/Stunts.Package/Stunt.cs
@@ -24,9 +24,13 @@ namespace Stunts
             {
                 var factoryType = Type.GetType(factoryAttribute.TypeName);
                 if (factoryType == null)
-                    throw new ArgumentException($"Stunt factory from provider {factoryAttribute.ProviderId} could not be loaded.");
+                    throw new ArgumentException($"Stunt factory from provider {factoryAttribute.ProviderId} could not be loaded from {factoryAttribute.TypeName}.");
 
                 StuntFactory.Default = (IStuntFactory)Activator.CreateInstance(factoryType);
+            }
+            else
+            {
+                throw new InvalidOperationException($"A valid stunt factory was not set as {nameof(StuntFactory)}.{nameof(StuntFactory.Default)} or registered for the current assembly with an [{nameof(StuntFactoryAttribute)}] attribute.");
             }
         }
 

--- a/src/Stunts.Package/Stunt.vb
+++ b/src/Stunts.Package/Stunt.vb
@@ -15,8 +15,10 @@ Namespace Global.Stunts
 
             If factoryAttribute IsNot Nothing Then
                 Dim factoryType = Type.[GetType](factoryAttribute.TypeName)
-                If factoryType Is Nothing Then Throw New ArgumentException($"Stunt factory from provider {factoryAttribute.ProviderId} could not be loaded.")
+                If factoryType Is Nothing Then Throw New ArgumentException($"Stunt factory from provider {factoryAttribute.ProviderId} could not be loaded from {factoryAttribute.TypeName}.")
                 StuntFactory.[Default] = CType(Activator.CreateInstance(factoryType), IStuntFactory)
+            Else
+                Throw New InvalidOperationException($"A valid stunt factory was not set as {NameOf(StuntFactory)}.{NameOf(StuntFactory.Default)} or registered for the current assembly with an [{NameOf(StuntFactoryAttribute)}] attribute.")
             End If
         End Sub
 

--- a/src/Stunts.Package/Stunts.Package.msbuildproj
+++ b/src/Stunts.Package/Stunts.Package.msbuildproj
@@ -24,5 +24,6 @@
     <ProjectReference Include="..\Stunts\Stunts.csproj" />
     <ProjectReference Include="..\Stunts.CodeAnalysis\Stunts.CodeAnalysis.csproj" />
     <ProjectReference Include="..\Stunts.StaticProxy\Stunts.StaticProxy.csproj" />
+    <ProjectReference Include="..\Stunts.DynamicProxy\Stunts.DynamicProxy.csproj" />
   </ItemGroup>
 </Project>

--- a/src/Stunts.Package/Stunts.targets
+++ b/src/Stunts.Package/Stunts.targets
@@ -1,9 +1,11 @@
 <Project>
 
   <!-- If source generators aren't supported, we just won't register the static one -->
-  <PropertyGroup Condition="'$(Language)' == 'C#' and ('$(LangVersion)' == '9.0' or '$(LangVersion)' == 'Preview') and 
-                             $(MSBuildShortVersion) &gt;= '16.8'">
-    <SourceGeneratorSupported>true</SourceGeneratorSupported>
+  <PropertyGroup>
+    <SourceGeneratorSupported Condition="'$(Language)' == 'C#' and ('$(LangVersion)' == '9.0' or '$(LangVersion)' == 'Preview') and 
+                                          $(MSBuildShortVersion) &gt;= '16.8'">true</SourceGeneratorSupported>
+    <RegisterStaticStuntFactory Condition="'$(RegisterStaticStuntFactory)' == '' and 
+                                           '$(SourceGeneratorSupported)' == 'true'">true</RegisterStaticStuntFactory>
   </PropertyGroup>
 
   <PropertyGroup>
@@ -11,7 +13,7 @@
     <StuntAnalyzerDir Condition="'$(MSBuildRuntimeType)' == 'Core'">$(MSBuildThisFileDirectory)..\..\tools\net5.0</StuntAnalyzerDir>
   </PropertyGroup>
 
-  <ItemGroup Condition="'$(SourceGeneratorSupported)' == 'true'">
+  <ItemGroup Condition="'$(RegisterStaticStuntFactory)' == 'true'">
     <CompilerVisibleProperty Include="DebugSourceGenerators" />
     <CompilerVisibleProperty Include="DebugStuntSourceGenerator" />
     <CompilerVisibleProperty Include="SkipCompilerExecution" />
@@ -19,15 +21,15 @@
     <CompilerVisibleProperty Include="StuntAnalyzerDir" />
   </ItemGroup>
 
-  <ItemGroup Condition="'$(SourceGeneratorSupported)' == 'true' and '$(MSBuildRuntimeType)' == 'Full' and '$(SkipCompilerExecution)' != 'true' and '$(DesignTimeBuild)' != 'true'">
+  <ItemGroup Condition="'$(RegisterStaticStuntFactory)' == 'true' and '$(MSBuildRuntimeType)' == 'Full' and '$(SkipCompilerExecution)' != 'true' and '$(DesignTimeBuild)' != 'true'">
     <Analyzer Include="$(MSBuildThisFileDirectory)..\..\tools\net472\Stunts*.dll" />
   </ItemGroup>
 
-  <ItemGroup Condition="'$(SourceGeneratorSupported)' == 'true' and '$(MSBuildRuntimeType)' == 'Core' and '$(SkipCompilerExecution)' != 'true' and '$(DesignTimeBuild)' != 'true'">
+  <ItemGroup Condition="'$(SourceGeneratorSupported)' == 'true' and '$(RegisterStaticStuntFactory)' != 'false' and '$(MSBuildRuntimeType)' == 'Core' and '$(SkipCompilerExecution)' != 'true' and '$(DesignTimeBuild)' != 'true'">
     <Analyzer Include="$(MSBuildThisFileDirectory)..\..\tools\net5.0\Stunts*.dll" />
   </ItemGroup>
 
-  <ItemGroup Condition="'$(SourceGeneratorSupported)' == 'true' and '$(RegisterStaticStuntFactory)' != 'false'">
+  <ItemGroup Condition="'$(RegisterStaticStuntFactory)' == 'true'">
     <StuntFactory Include="$(StaticStuntFactory)" PackageId="Stunts" />
   </ItemGroup>
 
@@ -41,7 +43,7 @@
   <Target Name="GetStuntFactoryAttributes" BeforeTargets="GetAssemblyAttributes" Returns="@(StuntFactory)">
     <ItemGroup>
       <!-- This adds all factories unconditionally, since the specific factories 
-           will actually check for duplicates and warn as needed. -->
+           will actually check for duplicates and warn if needed. -->
       <AssemblyAttribute Include="Stunts.StuntFactoryAttribute" Condition="'%(StuntFactory.Identity)' != ''">
         <_Parameter1>%(StuntFactory.Identity)</_Parameter1>
         <_Parameter2>%(StuntFactory.PackageId)</_Parameter2>
@@ -59,9 +61,9 @@
 
     <Warning Code="STB001" Condition="$(StuntFactories) &gt; '1'"
        Text="More than one stunt factory is registered in the current project. Only the first one will be used unless explicitly set as StuntFactory.Default. Packages providing factories: @(StuntFactoryPackage, ', ')." />
-
-    <Warning Code="STB002" Condition="'@(StuntFactory)' == '' and '$(SourceGeneratorSupported)' != 'true' and '$(RegisterStaticStuntFactory)' != 'false'"
-             Text="Built-in stunt factory requires C# 9.0. Please install Stunt.DynamicFactory package as an alternative." />
   </Target>
+
+  <Import Project="Stunts.DynamicProxy.targets"
+          Condition="'$(RegisterStaticStuntFactory)' != 'true' and  Exists('Stunts.DynamicProxy.targets')" />
 
 </Project>


### PR DESCRIPTION
At least initially, it doesn't make sense to force users to install the
Stunts.DynamicProxy when they are not on a C# 9 project does not seem like a great idea.

So we drop the standalone package, make it built-in via the Stunts.Package
project, and register the factory automatically whenever C# 9 isn't
supported.