### PR TITLE
Make sure to also pack as buildTransitive for generators

### DIFF
--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -5,7 +5,7 @@
     <PackageVersion Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.0" />
     <PackageVersion Include="ThisAssembly" Version="1.0.0-rc" />
     <PackageVersion Update="ThisAssembly" Version="42.42.42" Condition="Exists('$(MSBuildThisFileDirectory)..\..\ThisAssembly\bin\')" />
-    <PackageVersion Include="NuGetizer" Version="0.4.7" />
+    <PackageVersion Include="NuGetizer" Version="0.4.9" />
     <PackageVersion Update="NuGetizer" Version="42.42.42" Condition="Exists('$(MSBuildThisFileDirectory)..\..\nugetizer\bin\')" />
   </ItemGroup>
 

--- a/src/ManualStunts/Calculator.cs
+++ b/src/ManualStunts/Calculator.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿#nullable disable
+using System;
 using System.Collections.Generic;
 
 namespace Sample
@@ -8,7 +9,7 @@ namespace Sample
         CalculatorMemory memory = new CalculatorMemory();
         Dictionary<string, int> namedMemory = new Dictionary<string, int>();
 
-        public virtual event EventHandler? TurnedOn;
+        public virtual event EventHandler TurnedOn;
 
         public bool TurnOnCalled { get; set; }
 

--- a/src/ManualStunts/CalculatorBase.cs
+++ b/src/ManualStunts/CalculatorBase.cs
@@ -1,11 +1,12 @@
-﻿using System;
+﻿#nullable disable
+using System;
 
 namespace Sample
 {
     public abstract class CalculatorBase
     {
 #pragma warning disable CS0067
-        public virtual event EventHandler? TurnedOn;
+        public virtual event EventHandler TurnedOn;
 #pragma warning restore CS0067
 
         public abstract bool IsOn { get; }

--- a/src/ManualStunts/CalculatorClassStunt.cs
+++ b/src/ManualStunts/CalculatorClassStunt.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿#nullable disable
+using System;
 using System.Collections.Generic;
 using System.Reflection;
 using Stunts;
@@ -11,7 +12,7 @@ namespace Sample
 
         public IList<IStuntBehavior> Behaviors => pipeline.Behaviors;
 
-        public override event EventHandler? TurnedOn
+        public override event EventHandler TurnedOn
         {
             add => pipeline.Execute(new MethodInvocation(this, MethodBase.GetCurrentMethod(), value), (m, n) => { base.TurnedOn += value; return m.CreateValueReturn(null, value); });
             remove => pipeline.Execute(new MethodInvocation(this, MethodBase.GetCurrentMethod(), value), (m, n) => { base.TurnedOn -= value; return m.CreateValueReturn(null, value); });

--- a/src/ManualStunts/CalculatorInterfaceStunt.cs
+++ b/src/ManualStunts/CalculatorInterfaceStunt.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿#nullable disable
+using System;
 using System.Collections.Generic;
 using System.Reflection;
 using Stunts;

--- a/src/Pack/Pack.msbuildproj
+++ b/src/Pack/Pack.msbuildproj
@@ -3,8 +3,8 @@
   <Import Project="Pack.props" />
   <ItemGroup>
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" Visible="false" />
-    <PackageReference Include="NuGetizer" Version="0.4.7" Visible="false" />
-    <PackageReference Update="NuGetizer" Version="42.42.42" Visible="false" Condition="Exists('$(MSBuildThisFileDirectory)..\..\nugetizer\bin\')" />
+    <PackageReference Include="NuGetizer" Version="0.4.9" Visible="false" />
+    <PackageReference Update="NuGetizer" Version="42.42.42" Visible="false" Condition="Exists('$(MSBuildThisFileDirectory)..\..\..\nugetizer\bin\')" />
     <None Include="Pack.props" />
   </ItemGroup>
 </Project>

--- a/src/Stunts.DynamicProxy/Stunts.DynamicProxy.csproj
+++ b/src/Stunts.DynamicProxy/Stunts.DynamicProxy.csproj
@@ -27,7 +27,7 @@
   <ItemGroup>
     <!-- When not packed standalone, include the build targets/sources too -->
     <None Update="@(None)" PackFolder="build\netstandard2.0" Condition="'$(IsPackable)' != 'true'" />
-    <PackageFile Include="@(None -> '%(FullPath)')" PackFolder="buildTransitive\netstandard2.0" Condition="'$(IsPackable)' != 'true'" />
+    <PackageFile Include="@(None)" PackFolder="buildTransitive\netstandard2.0" Condition="'$(IsPackable)' != 'true'" />
   </ItemGroup>
 
 </Project>

--- a/src/Stunts.Package/Stunts.Package.msbuildproj
+++ b/src/Stunts.Package/Stunts.Package.msbuildproj
@@ -21,8 +21,8 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" Visible="false" Pack="false" />
-    <PackageReference Include="NuGetizer" Version="0.4.7" Visible="false" />
-    <PackageReference Update="NuGetizer" Version="42.42.42" Visible="false" Condition="Exists('$(MSBuildThisFileDirectory)..\..\nugetizer\bin\')" />
+    <PackageReference Include="NuGetizer" Version="0.4.9" Visible="false" />
+    <PackageReference Update="NuGetizer" Version="42.42.42" Visible="false" Condition="Exists('$(MSBuildThisFileDirectory)..\..\..\nugetizer\bin\')" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Stunts\Stunts.csproj" />


### PR DESCRIPTION
Both static and dynamic generators should automatically be available
for transitive packages too, to simplify deployment and consumption.